### PR TITLE
- removed "rate" option and restored the power-four score as the defa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,62 @@
 # Genome-targeting
 The folder genomes/ contains all the genomes used in this work
 The folder USER-SOFT-BLOB contains the LAMMPS implementation of the soft blob potential
+genome_overlap.py computes the overlap score for some set of probes and genomes.
 
-genome_overlap.py computes the overlap score for some set of probes and genomes. To use it first run
+### Compiling
+To use compute the overlap score, first run
 
     python3 setup.py build_ext -i
 
 to compile the cython extensions, and then run genome_overlap.py with the appropriate command-line arguments.
+
+### All probes or some probes?
+Computing the score function for every length-10nt probe (as we did) is feasible for most bacterial genomes.
+
+Computing the score function for every length-20nt probe (as we did NOT do) is both impractical (there are 1,099,511,627,776 of them) and unnecessary;
+the best scoring probe is most likely to be found among the most commonly-occuring subsequences of the genome
+(option --number-of-probes).
+
+For example, of the top 5000 most commonly-occuring length-10 subsequences of _E. coli_ strain bl21-de3 genome, the top-scoring sequence is the 14th most common.
+
+However, of the top 5000 most commonly-occuring length-20 subsequences in the same genome, the top-scoring sequence is **the** most common.
+
+The fraction of all possible probes you need to test (probably) decreases with increasing probe length and increasing genome length (don't quote me on that). 
+
+### Example usage
+Running:
+
+    python genome_overlap.py 10 8 genomes/rEC_bl21-de3.gen -c -n 20
+
+should yield:
+
+    JOB INFO:
+        number of threads: 8
+        probe length: 10
+        number of probes: 20 most common
+        genomes: ['genomes/rEC_bl21-de3.gen']
+        score function: power_four_score (i.e., the one used in Curk et al, PNAS (2020))
+        reverse complement?: yes
+        output file: stdout
+        
+    probe              rEC_bl21-de3
+    GCCGGATGCG        20.8797256088
+    CGCATCCGGC        20.8797256088
+    CTGGCGCTGG        21.2309825603
+    CCAGCGCCAG        21.2309825603
+    GCATCCGGCA        20.9125335234
+    TGCCGGATGC        20.9125335234
+    GCTGGCGCTG        21.2032711522
+    CAGCGCCAGC        21.2032711522
+    GCCGCATCCG        20.8121753470
+    CGGATGCGGC        20.8121753470
+    GGATGCGGCG        20.8510136192
+    CGCCGCATCC        20.8510136192
+    GGCGCTGGCG        21.2615020644
+    CGCCAGCGCC        21.2615020644
+    GATGCGGCGT        20.8617403144
+    ACGCCGCATC        20.8617403144
+    GCCTGATGCG        20.8592037187
+    CGCATCAGGC        20.8592037187
+    CCGGATGCGG        20.7754196406
+    CCGCATCCGG        20.7754196406

--- a/genome_overlap.py
+++ b/genome_overlap.py
@@ -5,11 +5,11 @@ def get_parser():
     parser = argparse.ArgumentParser(description="calculate the overlap score between a genome and all length l probes")
     parser.add_argument('length', type=int, help='probe length')
     parser.add_argument('threads', type=int, help='number of openmp threads to use', default=1)
-    parser.add_argument('-n', type=int, default=None, help=('only consider the n most common subsequences'
-                                                            ' in the genomes'))
-    parser.add_argument('-r', '--rate', type=float, default=1, help='rate parameter in the exponential weight')
-    parser.add_argument('--compare', action='store_true', help='compare the scores of all pairs of genomes')
-    parser.add_argument('--file', default=None, help='output file')
+    parser.add_argument('-n', '--number-of-probes', type=int,
+                        help='only consider the n most common subsequences in the genomes')
+    parser.add_argument('--compare', action='store_true',
+                        help='compare the scores of all pairs of genomes')
+    parser.add_argument('--file', help='output file')
     parser.add_argument('-c', '--do-reverse-complement', action='store_true',
                         help='include the reverse complement of the genome in the score calculation')
     parser.add_argument('genomes', nargs="+",
@@ -18,7 +18,7 @@ def get_parser():
 
 
 def main():
-    from genometargeting import exponential_score_factory, Genome, Computer
+    from genometargeting import power_four_score_factory, Genome, Computer
 
     parser = get_parser()
     args = parser.parse_args()
@@ -26,14 +26,30 @@ def main():
     gen_files = args.genomes
     length = args.length
     threads = args.threads
-    n = args.n
-    rate = args.rate
+    n = args.number_of_probes
     compare_flag = args.compare
     file = args.file
-    score_function = exponential_score_factory(rate, length)
+    score_function = power_four_score_factory(length)
     do_rc = args.do_reverse_complement
 
     genomes = *map(Genome.read, gen_files),
+
+    probe_info = f"{n} most common" if n is not None else f"{4**length} (all length {length} probes)"
+    score_function_info = (
+        f'{score_function.__name__} (i.e., the one used in Curk et al, PNAS (2020))'
+        if score_function.__name__ == "power_four_score"
+        else score_function.__name__
+    )
+    print(rf'''JOB INFO:
+    number of threads: {threads}
+    probe length: {length}
+    number of probes: {probe_info}
+    genomes: {gen_files}
+    score function: {score_function_info}
+    reverse complement?: {"yes" if do_rc else "no"}
+    output file: {file if file is not None else "stdout"}
+    ''', flush=True)
+
     compute = Computer(genomes, length, score_function, do_reverse_complement=do_rc)
     compute(threads, n, compare_flag, file)
 


### PR DESCRIPTION
Updated the genome overlap score function code and README to advise users how best to use the code, and to make it easier for users to reproduce the results in the paper.

- removed "rate" option and restored the power-four score as the default score function
- added a warning to the README about computing all probes for long probes
- added example usage to the README
- added some useful printing of job info before the job starts